### PR TITLE
feat: add Flair dashboard dApp

### DIFF
--- a/config/appsList.js
+++ b/config/appsList.js
@@ -79,6 +79,19 @@ const safeAppsConfig = [
     url: `https://furucombo.app/`,
     networks: [ETHEREUM_NETWORK.MAINNET],
   },
+  // Flair
+  {
+    url: `https://app.flair.finance/`,
+    networks: [
+      ETHEREUM_NETWORK.MAINNET,
+      ETHEREUM_NETWORK.BSC,
+      ETHEREUM_NETWORK.POLYGON,
+      ETHEREUM_NETWORK.RINKEBY,
+      ETHEREUM_NETWORK.ROPSTEN,
+      ETHEREUM_NETWORK.GOERLI,
+      ETHEREUM_NETWORK.XDAI,
+    ],
+  },
   // Gnosis Auction Starter
   {
     url: `${process.env.REACT_APP_IPFS_GATEWAY}/QmdCwUutYH8GXXNgTShB4cKJ8YJq4PqZ55QxMznKc9DbeS`,


### PR DESCRIPTION
Suggesting to add Flair dashboard to Safe Apps.

Flair helps builders and developers deploy ready-made smart contracts, and take advantage of a React SDK to interact with their contracts.

The platform provides contracts from NFT Sales, Token Staking and Streams, Revenue Sharing etc. At the moment only the "Tokens" features is compatible as a Safe App, we're going to adopt other features soon.

We'd really appreciate if you can review and if you think it's appropriate to merge 🙂 Some of our customers would like to create their contracts using the DAO/team multi-sig rather than a EOA.

<img width="1726" alt="Screenshot 2022-09-03 at 19 09 18" src="https://user-images.githubusercontent.com/1164589/188281298-b5163b2f-2391-4b52-921f-d4f55b5d13eb.png">
